### PR TITLE
docs: Add Edition Plugin System documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ WARScribe-Core provides the canonical implementation of WARScribe notation, the 
 - **Notation Engine**: Parse and generate WARScribe format
 - **Schema Definition**: Official WARScribe JSON schema
 - **Transformations**: Format conversions
+- **Edition Plugins**: Extensible game edition support
 
 ## Installation
 
@@ -25,6 +26,109 @@ git clone https://github.com/vindicta-platform/WARScribe-Core.git
 cd WARScribe-Core
 uv pip install -e .
 ```
+
+## Edition Plugin System
+
+WARScribe-Core uses a pluggable architecture for supporting different Warhammer 40K editions. Each edition defines its own phases, action validation, and game rules.
+
+### EditionPlugin Interface
+
+To create a custom edition plugin, extend the `EditionPlugin` abstract base class:
+
+| Property/Method | Type | Description |
+|-----------------|------|-------------|
+| `edition_name` | `str` | Human-readable edition name (e.g., "Warhammer 40,000 10th Edition") |
+| `edition_code` | `str` | Short identifier used for registration (e.g., "10th", "9th") |
+| `phases` | `Sequence[PhaseDefinition]` | Ordered sequence of game phases for this edition |
+| `validate_action(action, game_state)` | `ValidationResult` | Validates an action against edition rules |
+
+### Creating an Edition Plugin
+
+```python
+from typing import Any, Optional, Sequence
+
+from warscribe.edition import (
+    EditionPlugin,
+    GamePhase,
+    PhaseDefinition,
+    ValidationResult,
+)
+from warscribe.schema.action import Action, ActionType
+
+
+class NinthEditionPlugin(EditionPlugin):
+    """Example plugin for 9th Edition."""
+
+    @property
+    def edition_name(self) -> str:
+        return "Warhammer 40,000 9th Edition"
+
+    @property
+    def edition_code(self) -> str:
+        return "9th"
+
+    @property
+    def phases(self) -> Sequence[PhaseDefinition]:
+        return [
+            PhaseDefinition(
+                name=GamePhase.COMMAND,
+                display_name="Command Phase",
+                order=0,
+                allowed_actions=[ActionType.STRATAGEM, ActionType.ABILITY],
+            ),
+            PhaseDefinition(
+                name=GamePhase.MOVEMENT,
+                display_name="Movement Phase",
+                order=1,
+                allowed_actions=[ActionType.MOVE, ActionType.ADVANCE],
+            ),
+            PhaseDefinition(
+                name=GamePhase.PSYCHIC,
+                display_name="Psychic Phase",
+                order=2,
+                allowed_actions=[ActionType.ABILITY],
+            ),
+            # ... additional phases
+        ]
+
+    def validate_action(
+        self, action: Action, game_state: Optional[Any] = None
+    ) -> ValidationResult:
+        # Validate action against 9th Edition rules
+        if not self.is_action_allowed_in_phase(action.action_type, action.phase):
+            return ValidationResult.failure(
+                f"Action '{action.action_type.value}' not allowed in '{action.phase}'."
+            )
+        return ValidationResult.success()
+```
+
+### Supporting Types
+
+- **`PhaseDefinition`**: Defines a game phase with name, order, allowed actions, and optional description
+- **`ValidationResult`**: Result object with `is_valid`, `errors`, and `warnings` fields
+- **`GamePhase`**: Enum of standard phases (COMMAND, MOVEMENT, PSYCHIC, SHOOTING, CHARGE, FIGHT, MORALE)
+
+### EditionRegistry
+
+Register and retrieve edition plugins using the global registry:
+
+```python
+from warscribe.edition import register_edition, get_edition, get_edition_registry
+
+# Register a custom plugin
+register_edition(NinthEditionPlugin(), set_default=False)
+
+# Retrieve a registered plugin
+edition = get_edition("9th")
+
+# List all available editions
+registry = get_edition_registry()
+print(registry.available_editions)  # ["10th", "9th"]
+```
+
+### Reference Implementation
+
+See [`TenthEditionPlugin`](src/warscribe/edition/tenth.py) for a complete reference implementation of the 10th Edition rules.
 
 ## Related Repositories
 


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the Edition Plugin System to the README, making it clear how to create custom edition plugins for WARScribe-Core.

## Changes
- ✅ Added "Edition Plugin System" section to README
- ✅ Documented `EditionPlugin` abstract methods (`edition_name`, `edition_code`, `phases`, `validate_action`)
- ✅ Provided example of creating a new edition plugin (NinthEditionPlugin)
- ✅ Documented supporting types (`PhaseDefinition`, `ValidationResult`, `GamePhase`)
- ✅ Added `EditionRegistry` usage examples
- ✅ Linked to `TenthEditionPlugin` as reference implementation

## Closes
Closes #9

## Checklist
- [x] Add "Edition Plugin System" section to README
- [x] Document EditionPlugin abstract methods
- [x] Provide example of creating new edition plugin
- [x] Link to TenthEditionPlugin as reference implementation
- [x] Document EditionRegistry usage